### PR TITLE
Update examples link domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Found something cool? Please, **[contribute](https://github.com/feature-sliced/a
 
 ## Project examples
 
-We have a showcase of [examples](https://feature-sliced.design/examples) on our website.
+We have a showcase of [examples](https://feature-sliced.github.io/documentation/examples) on our website.
 
 ## DevExp
 


### PR DESCRIPTION
I’ve noticed that the link to the examples was outdated, so I updated the domain to the new one