### PR TITLE
Update README.md to reflect conarti/eslint-plugin-feature-sliced being deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We have a showcase of [examples](https://feature-sliced.github.io/documentation/
 
 - [Steiger](https://github.com/feature-sliced/steiger) <sub>[official]</sub> — A universal architectural linter with full support for FSD
 - [@feature-sliced/eslint-config](https://github.com/feature-sliced/eslint-config) — Official ESLint config
-- [@conarti/eslint-plugin-feature-sliced](https://github.com/conarti/eslint-plugin-feature-sliced) — Community plugin for ESLint
+- DEPRECATED ~~[@conarti/eslint-plugin-feature-sliced](https://github.com/conarti/eslint-plugin-feature-sliced) — Community plugin for ESLint~~
 
 ### Templates
 


### PR DESCRIPTION
`conarti/eslint-plugin-feature-sliced` being deprecated and it suggested to use `steiger` https://github.com/conarti/eslint-plugin-feature-sliced/issues/14#issuecomment-2380895561